### PR TITLE
rtusb_dev_id.c: add netgear wnda3100v3

### DIFF
--- a/common/rtusb_dev_id.c
+++ b/common/rtusb_dev_id.c
@@ -27,6 +27,7 @@
 /* module table */
 USB_DEVICE_ID rtusb_dev_id[] = {
 #ifdef MT76x2
+	{USB_DEVICE(0x0846, 0x9014), .driver_info = RLT_MAC_BASE}, /* Netgear WNDA3100v3 */
 	{USB_DEVICE(0x0B05, 0x180B), .driver_info = RLT_MAC_BASE}, /* ASUS USB-N53 */
 	{USB_DEVICE(0x0846, 0x9053), .driver_info = RLT_MAC_BASE}, /* MT7612U, Netgear A6210 */
 	{USB_DEVICE(0x0B05, 0x17EB), .driver_info = RLT_MAC_BASE}, /* ASUS USB-AC55 */


### PR DESCRIPTION
wnda3100v3 working quite well. Random timeouts though.. 14% packet loss from ~15 min ping test (~800 pings) to router

```
834 packets transmitted, 710 received, 14% packet loss, time 834115ms
rtt min/avg/max/mdev = 1.198/9.906/2048.857/115.701 ms, pipe 3
```
