### PR TITLE
Add support for the XBox One Wireless Adapter.

### DIFF
--- a/common/rtusb_dev_id.c
+++ b/common/rtusb_dev_id.c
@@ -31,6 +31,7 @@ USB_DEVICE_ID rtusb_dev_id[] = {
 	{USB_DEVICE(0x0B05, 0x180B), .driver_info = RLT_MAC_BASE}, /* ASUS USB-N53 */
 	{USB_DEVICE(0x0846, 0x9053), .driver_info = RLT_MAC_BASE}, /* MT7612U, Netgear A6210 */
 	{USB_DEVICE(0x0B05, 0x17EB), .driver_info = RLT_MAC_BASE}, /* ASUS USB-AC55 */
+	{USB_DEVICE(0x045e, 0x02e6), .driver_info = RLT_MAC_BASE}, /* Microsoft XBox One Wireless Adapter */
 	{USB_DEVICE(0x0E8D, 0x7612), .driver_info = RLT_MAC_BASE},
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0E8D, 0x7632, 0xff, 0xff, 0xff), .driver_info = RLT_MAC_BASE},
 	{USB_DEVICE_AND_INTERFACE_INFO(0x0E8D, 0x7662, 0xff, 0xff, 0xff), .driver_info = RLT_MAC_BASE},


### PR DESCRIPTION
This adds support for the Microsoft XBox One Wireless Adapter, which is in principle a USB WLAN dongle based on the MediaTek MT7612U chip. The driver is working, however, there is no LED support (yet) and the WPS feature state is unknown. There is still some research to be done regarding the actual integration of the gamepads. This will be done in a separate driver.